### PR TITLE
Set APPMENUS_DIR only when building a whonix template

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -7,3 +7,10 @@
 # template build scripts
 TEMPLATE_ENV_WHITELIST += WHONIX_APT_REPOSITORY_OPTS WHONIX_ENABLE_TOR \
     WHONIX_DIR WHONIX_TBB_VERSION
+
+# set APPMENUS_DIR only when building a whonix template
+ifeq (1,$(TEMPLATE_BUILDER))
+ifneq (,$(findstring whonix, $(TEMPLATE_FLAVOR)))
+APPMENUS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+endif
+endif

--- a/builder.conf
+++ b/builder.conf
@@ -70,7 +70,6 @@ $(strip $(foreach _alias, $(TEMPLATE_ALIAS), $(_aliases)))
 # Define flavor directory location (here)
 # ------------------------------------------------------------------------------
 WHONIX_DIR := $(BUILDER_DIR)/$(SRC_DIR)/Whonix
-APPMENUS_DIR := $(BUILDER_DIR)/$(SRC_DIR)/$(_self)
 TEMPLATE_FLAVOR_DIR += +whonix-gateway:$(BUILDER_DIR)/$(SRC_DIR)/$(_self)
 TEMPLATE_FLAVOR_DIR += +whonix-workstation:$(BUILDER_DIR)/$(SRC_DIR)/$(_self)
 


### PR DESCRIPTION
Do not set it in builder.conf which gets sourced at every build (with
this builder plugin enabled). This would pollute build environment for
non-whonix builds resulting in missing appmenus there.

See https://github.com/QubesOS/qubes-linux-template-builder/pull/6 for
details.